### PR TITLE
add "registerModules" method to register several modules at the same time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ This container works in a very simple way: you **register** modules/services wit
   * `[depName, depName,...]`- this modules dependencies (their names) or an empty Array
   * `implementation` - this module implementation. If the module has dependencies, this **must be a function** accepting the dependencies in the same order. The container will throw an Error if the number of declared dependencies doesn't match the factory function arity. If the module has no dependencies, it can be a plain Object.
 
+## Registering several modules
+```javascript
+container.registerModules({
+	'name': { deps: [depName, depName,...], impl: implementation},
+	'otherName': { deps: [depName, depName,...], impl: implementation},
+	.....
+	});
+```
+* Registers a list of modules in the container,  *Alias: `registerAll`*. The parameters is an object with:
+	* `name`- the name of the module, will be used as dependency name in other modules, and for getting/starting/stopping it.
+	* Object with properties:
+  	* `deps` - (optional if the module has no dependencies) this modules dependencies (their names) or an empty Array
+  	* `impl` - this module implementation. If the module has dependencies, this **must be a function** accepting the dependencies in the same order. The container will throw an Error if the number of declared dependencies doesn't match the factory function arity. If the module has no dependencies, it can be a plain Object.
+
 ## Obtaining modules
 * `container.getModule(name)` - Retrieves the given module from the container, with all its dependencies injected, if any. *Alias: `get`*
 * `container.startModule(name[, options])`- Retrieves the given module from the container, automatically calling the module's `start` function if it exists. If your module needs to do some async stuff, make this function return a Promise (a *thenable* to be specific) and pass in `{async: true}` in options.

--- a/container.js
+++ b/container.js
@@ -11,6 +11,16 @@ var Container = {
 
   modules: {},
 
+  registerModules: function(modules) {
+    modules = modules || {};
+    var key;
+    for(key in modules) {
+      if(modules.hasOwnProperty(key) && modules[key].impl) {
+        Container.registerModule(key, modules[key].deps || [], modules[key].impl);
+      }
+    }
+  },
+
   /** Registers a module. Each module should return a function
   to be called with all its dependencies in order */
   registerModule: function(moduleName, dependencies, moduleDef){
@@ -186,5 +196,6 @@ Container.register = Container.registerModule;
 Container.get = Container.getModule;
 Container.start = Container.startModule;
 Container.stop = Container.stopModule;
+Container.registerAll = Container.registerModules;
 
 module.exports = Container;

--- a/examples/async_registerModules/app.js
+++ b/examples/async_registerModules/app.js
@@ -1,0 +1,8 @@
+var kontainer = require('./containerConfig');
+
+
+var webApp;
+
+kontainer.startModule('web', { async: true }).then(function(webApp){
+  console.log('Web app started on ', webApp.port);
+});

--- a/examples/async_registerModules/config.js
+++ b/examples/async_registerModules/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  serverPort: 4505
+}

--- a/examples/async_registerModules/containerConfig.js
+++ b/examples/async_registerModules/containerConfig.js
@@ -1,0 +1,12 @@
+var kontainer = require('../../container');
+var config = require('./config');
+var webServer = require('./server');
+
+
+kontainer.registerModules({
+	'config': { impl: config}, // when depdencies are empty "[]", it's optional
+	'web': { deps: ['config'], impl: webServer }
+});;
+
+
+module.exports = kontainer;

--- a/examples/async_registerModules/server.js
+++ b/examples/async_registerModules/server.js
@@ -1,0 +1,36 @@
+'use strict';
+var http = require('http');
+var Promise = require('bluebird');
+
+/**
+
+Example of async module start. In this case this module
+is starting an HTTP server which is by definition an async operation
+so we return a Promise.
+
+This module should be started with
+kontainer.start('moduleName', {async: true});
+
+**/
+var ServerFactory = function(config){
+  var server = http.createServer();
+
+  function start(){
+    return new Promise(function(resolve, reject){
+      server.listen(config.serverPort, function(err){
+        if(err){
+          reject(err);
+        }
+        resolve();
+      });
+    });
+  }
+
+  return {
+    start: start,
+    port: config.serverPort
+  };
+
+}
+
+module.exports = ServerFactory;

--- a/examples/basic_registerModules/app.js
+++ b/examples/basic_registerModules/app.js
@@ -1,0 +1,6 @@
+var kontainer = require('./containerConfig');
+
+var userService = kontainer.get('userService');
+var users = userService.getUsers();
+console.log(users);
+

--- a/examples/basic_registerModules/config.js
+++ b/examples/basic_registerModules/config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  server: 'testserver',
+  database: 'test',
+  username: 'foo',
+  password: 'f00'
+};

--- a/examples/basic_registerModules/containerConfig.js
+++ b/examples/basic_registerModules/containerConfig.js
@@ -1,0 +1,15 @@
+var kontainer = require('../../container');
+
+var config = require('./config'),
+    databaseFactory = require('./lib/database'),
+    userServiceFactory = require('./services/user_service');
+
+
+kontainer.registerModules({
+	'config': { impl: config},
+	'database': { deps: ['config'], impl: databaseFactory },
+	'userService': { deps: ['database'], impl: userServiceFactory },
+});
+
+//export the configured DI container
+module.exports = kontainer;

--- a/examples/es2015_registerModules/app.js
+++ b/examples/es2015_registerModules/app.js
@@ -1,0 +1,31 @@
+// Run this example in a recent version of Node.js (e.g 5.5.0)
+'use strict';
+
+const container = require('../../container');
+
+
+class Engine {
+  goes() {
+    return 'Wrooom!!!';
+  }
+}
+
+class Car {
+  constructor(engine) {
+    this.engine = engine;
+  }
+}
+
+
+container.registerModules({
+	'engine': { impl: Engine },
+	'car': { deps: ['engine'], impl: Car },
+});
+
+const car = container.get('car');
+
+console.log('The car has an ', car.engine);
+console.log('If it\'s not a Tesla, then the engine goes', car.engine.goes());
+
+//export the configured DI container
+module.exports = container;

--- a/examples/express_registerModules/README.md
+++ b/examples/express_registerModules/README.md
@@ -1,0 +1,24 @@
+
+# Kontainer DI - Express example #
+
+This folder contains a complete Node.js project featuring the DI container in a more real-world environment.
+
+The project contains a REST API for a Todo application, backed by a SQLite database. It will automatically create the database schema and and a few items the first time the application is started.
+
+You can checkout the container configuration for runtime as well as the test version under `tests/helpers`.
+
+## Installation ##
+```
+npm install
+```
+
+## Running the application ##
+```
+npm start
+```
+
+## Running the tests ##
+```
+npm test
+```
+

--- a/examples/express_registerModules/containerConfig.js
+++ b/examples/express_registerModules/containerConfig.js
@@ -1,0 +1,26 @@
+// DI container configuration file
+
+var container = require('kontainer-di'),
+    dbConfig = require('./config/database'),
+    serverConfig = require('./config/server');
+
+var databaseFactory = require('./services/database'),
+    todoServiceFactory = require('./services/todo_service');
+
+var serverFactory = require('./modules/server'),
+    todoApiFactory = require('./modules/todo_api');
+
+
+container.registerModules({
+	'dbConfig': { impl: dbConfig },
+	'serverConfig': { impl: serverConfig },
+
+	'database': { deps: ['dbConfig'], impl: databaseFactory },
+	'todoService': { deps: ['database'], impl: todoServiceFactory },
+
+	'server': { deps: ['serverConfig'], impl: serverFactory },
+	'todoApi': { deps: ['server', 'todoService'], impl: todoApiFactory },
+});
+
+
+module.exports = container;

--- a/examples/express_registerModules/index.js
+++ b/examples/express_registerModules/index.js
@@ -1,0 +1,26 @@
+'use strict';
+var container = require('./containerConfig');
+
+
+var knex, todoApi;
+
+knex = container.get('database');
+knex.migrate.latest()
+.then(function(){
+  console.log('SQLite database ready');
+  //retrieve the TodoApi, just so it wires itself with Express
+  todoApi = container.get('todoApi');
+  // although the server module was already instantiated with the line above
+  // its 'start' method hasn't been called yet, so we launch the http server here
+  var server = container.startModule('server', { async: true })
+    .then(function(server){
+      console.log('Example App ready, visit the /todos url in your browser');
+      console.log('Available methods');
+      console.log('\tGET /todos');
+      console.log('\tGET /todos/:id');
+      console.log('\tPOST /todos');
+      console.log('\tPUT /todos/:id');
+      console.log('\tDELETE /todos/:id');
+    });
+
+});

--- a/examples/express_registerModules/knexfile.js
+++ b/examples/express_registerModules/knexfile.js
@@ -1,0 +1,44 @@
+// Update with your config settings.
+
+module.exports = {
+
+  development: {
+    client: 'sqlite3',
+    connection: {
+      filename: './data/todos.sqlite3'
+    }
+  },
+
+  staging: {
+    client: 'postgresql',
+    connection: {
+      database: 'my_db',
+      user:     'username',
+      password: 'password'
+    },
+    pool: {
+      min: 2,
+      max: 10
+    },
+    migrations: {
+      tableName: 'knex_migrations'
+    }
+  },
+
+  production: {
+    client: 'postgresql',
+    connection: {
+      database: 'my_db',
+      user:     'username',
+      password: 'password'
+    },
+    pool: {
+      min: 2,
+      max: 10
+    },
+    migrations: {
+      tableName: 'knex_migrations'
+    }
+  }
+
+};

--- a/examples/express_registerModules/package.json
+++ b/examples/express_registerModules/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "kontainer-di-express-example",
+  "version": "0.1.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha test/unit",
+    "start": "node index"
+  },
+  "author": "cdelaorden",
+  "license": "GPL-3.0",
+  "dependencies": {
+    "bluebird": "^2.9.34",
+    "body-parser": "^1.13.3",
+    "express": "^4.13.3",
+    "knex": "^0.8.6",
+    "kontainer-di": "^0.9.5",
+    "mocha": "^2.2.5",
+    "sqlite3": "^3.0.10"
+  },
+  "devDependencies": {
+    "sinon": "^1.15.4"
+  }
+}

--- a/test/container.js
+++ b/test/container.js
@@ -42,7 +42,80 @@ describe('Module Container', function(){
     };
   });
 
-  describe('Registration', function(){
+
+  describe('registerModules function ', function(){
+    it('Should accept module registration', function(){
+      container.registerModules({
+        'A': { deps: [], impl: moduleA},
+        'B': { deps: ['A'], impl: moduleB },
+      });
+    });
+
+    it('Should accept either a factory or an instance', function(){
+      var modFoo, modBar;
+      container.registerModules({
+        'A': { deps: [], impl: { foo: 'bar' } },
+        'B': { deps: ['A'], impl: function(aModule) { return { foo: 'bar' }; } },
+      });
+      modFoo = container.getModule('A');
+      modFoo.should.be.an.Object;
+      modFoo.should.have.property('foo', 'bar');
+
+      modBar = container.getModule('B');
+      modBar.should.be.an.Object;
+      modBar.should.have.property('foo', 'bar');
+    });
+
+    it('Should reject an object module with dependencies', function(){
+      container.register.bind(container, {
+          'A': { deps: ['C'], impl: { foo: 'bar'} }
+        }).should.throw();
+    });
+
+    it('Should throw an error if registering a duplicate module', function(){
+      container.registerModules({
+        'A': { desp: [], impl: moduleA },
+      });
+      container.register.bind(container, { 'A': {impl: moduleA } })
+        .should.throw();
+    });
+
+    it('Should throw an error if registering a duplicate module', function(){
+      container.registerModules({
+        'A': { desp: [], impl: moduleA },
+        'B': { deps: ['A'], impl: moduleB },
+      });
+      container.register.bind(container, { 'B': { deps: ['A'], impl: moduleB } })
+        .should.throw();
+    });
+
+    it('Should throw an error if the factory function doesn\'t accept the same number of dependencies', function(){
+      container.registerModules({ 'A': { desp: [], impl: moduleA } });
+      container.register.bind(container,
+        { 'B': { deps: ['A','D','E'], imple: moduleB } }).should.throw();
+    });
+
+    it('Should allow clearing a module', function(){
+      container.registerModules({
+        'A': { desp: [], impl: moduleA },
+        'B': { deps: ['A'], impl: moduleB },
+      });
+
+      container.clearModule('A');
+      container.clearModule('B');
+
+      container.registerModule('A', [], moduleA);
+      container.registerModule('B', ['A'], moduleB);
+    });
+
+    it('Should throw an error when clearing an instantiated module', function(){
+      container.registerModules({ 'A': { desp: [], impl: moduleA } });
+      container.getModule('A');
+      container.clearModule.bind(container, 'A').should.throw();
+    });
+  });
+
+  describe('registerModule function', function(){
     it('Should accept module registration', function(){
       container.registerModule('A', [], moduleA);
     });
@@ -313,6 +386,17 @@ describe('Module Container', function(){
       container.register('A', [], moduleA);
       var modA = container.getModule('A');
       modA.should.be.an.Object;
+    });
+
+    it('Should allow using registerAll instead of registerModules', function(){
+      container.registerAll({
+        'A': { impl: moduleA },
+        'B': { deps: ['A'], impl: moduleB },
+      });
+      var modA = container.getModule('A');
+      modA.should.be.an.Object;
+      var modB = container.getModule('B');
+      modB.should.be.an.Object;
     });
 
     it('Should allow using get instead of getModule', function(){


### PR DESCRIPTION
Hi, 
I added a new method to allow you register several methods at the same time, doing:

```
container.registerAll({
        'A': { impl: moduleA },
        'B': { deps: ['A'], impl: moduleB },
        ...
      });
```

All test are working.
New examples with this function was created. The only example that is not working is the "express_registerModules" because of it downloads "kontainer-di" from npm and the version uploaded has not the new "registerModules" method.

There is also a alias (registerAll) for the new method.
